### PR TITLE
bump substreams-sink-files spkg dependency to fix protobuf issue in substreams client

### DIFF
--- a/substreams.yaml
+++ b/substreams.yaml
@@ -4,7 +4,7 @@ package:
   version: v0.1.0
 
 imports:
-  sink_files: https://github.com/streamingfast/substreams-sink-files/releases/download/v0.2.0/substreams-sink-files-v0.2.0.spkg
+  sink_files: https://github.com/streamingfast/substreams-sink-files/releases/download/v2.1.0/substreams-sink-files-v2.1.0.spkg
   sql: https://github.com/streamingfast/substreams-sink-sql/releases/download/protodefs-v1.0.7/substreams-sink-sql-protodefs-v1.0.7.spkg
   graph: https://github.com/streamingfast/substreams-sink-subgraph/releases/download/v0.1.0/substreams-sink-subgraph-protodefs-v0.1.0.spkg
   database_change: https://github.com/streamingfast/substreams-sink-database-changes/releases/download/v1.2.1/substreams-database-change-v1.2.1.spkg


### PR DESCRIPTION
fixes this error when running substreams (version >= v1.5.6) with substreams.yaml:

```Error: building message descriptors: couldn't convert, should do this check much earlier: proto: message field "sf.substreams.rpc.v2.BlockUndoSignal.last_valid_block" cannot resolve type: "sf.substreams.v1.BlockRef" not found```

Bumping the sink_files spkg release version prevents this error.